### PR TITLE
chore: add exclude for images before publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 homepage = "https://github.com/jasmith79/playlistrs"
 license = "MIT"
 repository = "https://github.com/jasmith79/playlistrs"
+exclude = [
+  "resources/*"
+]
 
 [[bin]]
 name = "playlistrs"


### PR DESCRIPTION
Don't need to upload instructional images to crates.io